### PR TITLE
WP 7 RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-03-25
+
+### Removed
+
+- Reflection-based event dispatcher injection workaround — fixed in WP 7 RC1 (core now passes `AiClient::getEventDispatcher()` in the `WP_AI_Client_Prompt_Builder` constructor).
+
+### Changed
+
+- Tested up to WP 7.0-RC1.
+- Updated howto documentation to mark the core bug as resolved.
+
 ## [0.4.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Control, meter, and permission-gate AI usage from plugins that connect through the WordPress 7 AI connector.
 
-> Tested using WordPress [AI](https://wordpress.org/plugins/ai/),  [Virtual Media Folders AI Organizer](https://github.com/soderlind/vmfa-ai-organizer?tab=readme-ov-file#virtual-media-folders-ai-organizer) and the [AI Provider for Azure OpenAI](https://github.com/soderlind/ai-provider-for-azure-openai?tab=readme-ov-file#ai-provider-for-azure-openai).
+> Works with WordPress 7 RC1. Tested using WordPress [AI](https://wordpress.org/plugins/ai/),  [Virtual Media Folders AI Organizer](https://github.com/soderlind/vmfa-ai-organizer?tab=readme-ov-file#virtual-media-folders-ai-organizer) and the [AI Provider for Azure OpenAI](https://github.com/soderlind/ai-provider-for-azure-openai?tab=readme-ov-file#ai-provider-for-azure-openai).
 
 <img width="100%"  alt="Screenshot 2026-03-24 at 23 55 20" src="https://github.com/user-attachments/assets/3b619ba2-1432-4029-be3f-7556bcb991e2" />
 

--- a/ai-valve.php
+++ b/ai-valve.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Valve
  * Plugin URI:  https://github.com/soderlind/ai-valve
  * Description: Control, meter, and permission-gate AI usage from plugins that connect through the WordPress 7 AI connector.
- * Version:     0.4.0
+ * Version:     0.5.0
  * Requires at least: 7.0
  * Requires PHP: 8.3
  * Author:      Per Søderlind
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-define( 'AI_VALVE_VERSION', '0.4.0' );
+define( 'AI_VALVE_VERSION', '0.5.0' );
 define( 'AI_VALVE_FILE', __FILE__ );
 define( 'AI_VALVE_DIR', __DIR__ );
 define( 'AI_VALVE_BASENAME', plugin_basename( __FILE__ ) );

--- a/docs/howto-intercept-wp7-ai-requests.md
+++ b/docs/howto-intercept-wp7-ai-requests.md
@@ -1,6 +1,6 @@
 # How to Intercept WordPress 7 AI Connector Requests
 
-A practical guide to hooking into the WP 7 AI client, working around the event-dispatcher bug, and correctly reading token usage from the SDK.
+A practical guide to hooking into the WP 7 AI client and correctly reading token usage from the SDK.
 
 ---
 
@@ -33,81 +33,17 @@ add_action( 'wp_ai_client_after_generate_result', function ( AfterGenerateResult
 
 ---
 
-## WP 7.0 Core Bug: Event Dispatcher Not Injected
+## ~~WP 7.0 Core Bug: Event Dispatcher Not Injected~~ (Fixed in RC1)
 
-### Symptom
-
-`wp_ai_client_prevent_prompt` fires normally, but `wp_ai_client_before_generate_result` and `wp_ai_client_after_generate_result` **never fire**.
-
-### Root Cause
-
-In `wp-includes/ai-client.php`, the function `wp_ai_client_prompt()` creates the prompt builder like this:
-
-```php
-new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), $prompt );
-```
-
-The underlying SDK `PromptBuilder` constructor accepts an **optional third parameter**:
-
-```php
-public function __construct(
-    ProviderRegistryInterface $registry,
-    string $prompt,
-    ?EventDispatcherInterface $eventDispatcher = null,  // <-- never passed
-)
-```
-
-Because `$eventDispatcher` is never passed, it stays `null`. The SDK's `dispatchEvent()` method silently skips all event dispatching when the dispatcher is null:
-
-```php
-// PromptBuilder.php line ~1460
-private function dispatchEvent( object $event ): void {
-    if ( null !== $this->eventDispatcher ) {
-        $this->eventDispatcher->dispatch( $event );
-    }
-}
-```
-
-Meanwhile, `wp-settings.php` **does** set a global dispatcher via `AiClient::setEventDispatcher(new WP_AI_Client_Event_Dispatcher())` — it's just never plumbed into the PromptBuilder.
-
-### Workaround: Reflection Injection
-
-The `prevent_prompt` filter receives a **clone** of the `WP_AI_Client_Prompt_Builder`. Crucially, `WP_AI_Client_Prompt_Builder` has no `__clone()` method, so PHP performs a shallow copy — the clone shares the **same inner SDK `PromptBuilder` object**. Modifying it via the clone propagates to the original.
-
-Use an early-priority filter to inject the dispatcher before anything else runs:
-
-```php
-use WordPress\AiClient\AiClient;
-
-add_filter( 'wp_ai_client_prevent_prompt', function ( bool $prevent, \WP_AI_Client_Prompt_Builder $builder ): bool {
-    try {
-        // Reach the private SDK PromptBuilder inside the WP wrapper.
-        $wp_ref       = new ReflectionClass( $builder );
-        $builder_prop = $wp_ref->getProperty( 'builder' );
-        $sdk_builder  = $builder_prop->getValue( $builder );
-
-        // Check if the dispatcher is already set.
-        $sdk_ref   = new ReflectionClass( $sdk_builder );
-        $disp_prop = $sdk_ref->getProperty( 'eventDispatcher' );
-        $current   = $disp_prop->getValue( $sdk_builder );
-
-        if ( null === $current ) {
-            $dispatcher = AiClient::getEventDispatcher();
-            if ( null !== $dispatcher ) {
-                $disp_prop->setValue( $sdk_builder, $dispatcher );
-            }
-        }
-    } catch ( \Throwable ) {
-        // Reflection failed — don't break the request.
-    }
-
-    return $prevent;
-}, 5, 2 ); // Priority 5 — before any policy/gating filters at 10.
-```
-
-**Why priority 5?** The injection must happen before any filter at priority 10+ that relies on the before/after actions firing. Since `prevent_prompt` is the only hook that fires before the HTTP call, it's the only place to fix the dispatcher.
-
-**Will this break when WP fixes the bug?** No. The code checks `if ( null === $current )` — once core passes the dispatcher properly, the reflection is skipped entirely.
+> **Resolved.** WP 7.0 beta shipped without passing the event dispatcher to the SDK
+> `PromptBuilder`. This caused `wp_ai_client_before_generate_result` and
+> `wp_ai_client_after_generate_result` to never fire. AI Valve previously worked
+> around the bug by injecting the dispatcher via reflection at priority 5 of the
+> `wp_ai_client_prevent_prompt` filter.
+>
+> As of **WP 7 RC1**, the `WP_AI_Client_Prompt_Builder` constructor now passes
+> `AiClient::getEventDispatcher()` to the SDK `PromptBuilder` directly. The
+> reflection workaround has been removed from AI Valve.
 
 ---
 
@@ -188,18 +124,11 @@ foreach ( $trace as $frame ) {
 
 ## Complete Logging Example
 
-Putting it all together — a self-contained snippet that injects the dispatcher, gates requests, and logs token usage:
+Putting it all together — a self-contained snippet that gates requests and logs token usage:
 
 ```php
-add_filter( 'wp_ai_client_prevent_prompt', 'my_inject_dispatcher', 5, 2 );
 add_filter( 'wp_ai_client_prevent_prompt', 'my_gate_prompt', 10, 2 );
 add_action( 'wp_ai_client_after_generate_result', 'my_log_usage', 10, 1 );
-
-function my_inject_dispatcher( bool $prevent, WP_AI_Client_Prompt_Builder $builder ): bool {
-    // See "Workaround: Reflection Injection" above.
-    // ... reflection code ...
-    return $prevent;
-}
 
 function my_gate_prompt( bool $prevent, WP_AI_Client_Prompt_Builder $builder ): bool {
     if ( $prevent ) {
@@ -237,7 +166,7 @@ If hooks aren't firing as expected:
 
 1. **Is the AI connector configured?** — `wp_supports_ai()` must return `true`.
 2. **Is `wp_ai_client_prompt()` being used?** — Only this function triggers the hooks. Direct SDK usage bypasses them.
-3. **Are before/after actions silent?** — Apply the reflection workaround above (WP 7.0 core bug).
+3. **Are before/after actions silent?** — Ensure you're on WP 7 RC1+. Earlier betas had a core bug where the event dispatcher wasn't injected (now fixed).
 4. **Are you getting errors on token access?** — Use getter methods, not property access.
 5. **Is your `prevent_prompt` filter returning the wrong type?** — Must return `bool`. Returning a non-bool can break the filter chain.
 6. **Check hook registration:** `wp eval 'var_dump( has_filter("wp_ai_client_prevent_prompt") );'`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ai-valve",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"private": true,
 	"scripts": {
 		"build": "wp-scripts build src/js/index.js --output-path=build",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: PerS
 Tags: ai, tokens, metering, permissions, usage
 Requires at least: 7.0
-Tested up to: 7.0
+Tested up to: 7.0-RC1
 Requires PHP: 8.3
-Stable tag: 0.4.0
+Stable tag: 0.5.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,9 +51,9 @@ A limit of 0 means unlimited — no cap is enforced. Set a positive number to re
 
 It walks the PHP call stack (`debug_backtrace()`) and matches file paths against the plugins directory to determine the originating plugin slug.
 
-= Will this work when the WordPress core bug is fixed? =
+= Will this work with future WordPress updates? =
 
-Yes. AI Valve includes a workaround that checks whether the event dispatcher is already set. Once WordPress core passes it properly, the workaround is automatically skipped.
+Yes. AI Valve relies only on the stable public hooks (`wp_ai_client_prevent_prompt`, `wp_ai_client_before_generate_result`, `wp_ai_client_after_generate_result`) provided by the WordPress AI connector API.
 
 = Does AI Valve work on multisite? =
 
@@ -64,6 +64,11 @@ Yes. Each subsite has its own log table, settings, and budgets.
 The plugin receives a `WP_Error` with code `prompt_prevented` instead of an AI response. The denied request is logged with the reason. See [how-blocking-works.md](https://github.com/soderlind/ai-valve/blob/main/docs/how-blocking-works.md) for the full explanation.
 
 == Changelog ==
+
+= 0.5.0 =
+* Removed: Reflection-based event dispatcher injection workaround (fixed in WP 7 RC1).
+* Changed: Tested up to WP 7.0-RC1.
+* Changed: Updated howto documentation to mark the core bug as resolved.
 
 = 0.4.0 =
 * Changed: Admin UI rebuilt as a React single-page application.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: PerS
 Tags: ai, tokens, metering, permissions, usage
 Requires at least: 7.0
-Tested up to: 7.0-RC1
+Tested up to: 7.0
 Requires PHP: 8.3
 Stable tag: 0.5.0
 License: GPL-2.0-or-later

--- a/src/Interceptor/RequestInterceptor.php
+++ b/src/Interceptor/RequestInterceptor.php
@@ -7,7 +7,6 @@ namespace AIValve\Interceptor;
 use AIValve\Settings\Settings;
 use AIValve\Tracking\LogRepository;
 use AIValve\Tracking\UsageTracker;
-use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Events\AfterGenerateResultEvent;
 use WordPress\AiClient\Events\BeforeGenerateResultEvent;
 use WP_AI_Client_Prompt_Builder;
@@ -15,14 +14,9 @@ use WP_AI_Client_Prompt_Builder;
 /**
  * Wires the three WP 7 AI connector hooks:
  *
- * 1. `wp_ai_client_prevent_prompt`        — gate / ACL + inject event dispatcher
+ * 1. `wp_ai_client_prevent_prompt`        — gate / ACL
  * 2. `wp_ai_client_before_generate_result` — start tracking
  * 3. `wp_ai_client_after_generate_result`  — log token usage
- *
- * NOTE: WP 7.0 has a core bug where `wp_ai_client_prompt()` creates the
- * PromptBuilder without passing the event dispatcher. We fix this by injecting
- * the dispatcher via reflection in our `prevent_prompt` filter. The clone
- * shares the same inner SDK PromptBuilder, so the fix propagates to the original.
  */
 final class RequestInterceptor {
 
@@ -36,44 +30,9 @@ final class RequestInterceptor {
 	) {}
 
 	public function register(): void {
-		// Priority 5: inject event dispatcher before any other prevent_prompt filter.
-		add_filter( 'wp_ai_client_prevent_prompt', [ $this, 'ensure_event_dispatcher' ], 5, 2 );
-		// Priority 10: evaluate policy.
 		add_filter( 'wp_ai_client_prevent_prompt', [ $this, 'maybe_prevent' ], 10, 2 );
 		add_action( 'wp_ai_client_before_generate_result', [ $this, 'on_before_generate' ], 10, 1 );
 		add_action( 'wp_ai_client_after_generate_result', [ $this, 'on_after_generate' ], 10, 1 );
-	}
-
-	/* ------------------------------------------------------------------
-	 * 0. Fix WP 7 core bug — inject event dispatcher into PromptBuilder
-	 *
-	 * wp_ai_client_prompt() creates WP_AI_Client_Prompt_Builder which
-	 * constructs the SDK PromptBuilder WITHOUT passing the event dispatcher.
-	 * The prevent_prompt filter receives a clone that shares the same inner
-	 * PromptBuilder, so we inject the dispatcher via reflection here.
-	 * ----------------------------------------------------------------*/
-
-	public function ensure_event_dispatcher( bool $prevent, WP_AI_Client_Prompt_Builder $builder ): bool {
-		try {
-			$wp_ref      = new \ReflectionClass( $builder );
-			$builder_prop = $wp_ref->getProperty( 'builder' );
-			$sdk_builder = $builder_prop->getValue( $builder );
-
-			$sdk_ref     = new \ReflectionClass( $sdk_builder );
-			$disp_prop   = $sdk_ref->getProperty( 'eventDispatcher' );
-			$current     = $disp_prop->getValue( $sdk_builder );
-
-			if ( null === $current ) {
-				$dispatcher = AiClient::getEventDispatcher();
-				if ( null !== $dispatcher ) {
-					$disp_prop->setValue( $sdk_builder, $dispatcher );
-				}
-			}
-		} catch ( \Throwable ) {
-			// Reflection failed — don't block the request.
-		}
-
-		return $prevent;
 	}
 
 	/* ------------------------------------------------------------------

--- a/tests/Unit/Interceptor/RequestInterceptorTest.php
+++ b/tests/Unit/Interceptor/RequestInterceptorTest.php
@@ -45,9 +45,6 @@ final class RequestInterceptorTest extends TestCase {
 
 		// Brain Monkey tracks add_filter / add_action calls.
 		$this->assertTrue(
-			Filters\has( 'wp_ai_client_prevent_prompt', [ $interceptor, 'ensure_event_dispatcher' ] ) !== false
-		);
-		$this->assertTrue(
 			Filters\has( 'wp_ai_client_prevent_prompt', [ $interceptor, 'maybe_prevent' ] ) !== false
 		);
 		$this->assertTrue(


### PR DESCRIPTION
This release updates AI Valve to version 0.5.0, primarily removing the reflection-based workaround for a WordPress core bug that prevented event hooks from firing. With the bug fixed in WordPress 7 RC1, related code and documentation have been cleaned up. The release also updates compatibility information and clarifies documentation to reflect the resolved issue.

**Core compatibility and event dispatcher changes:**
- Removed the reflection-based event dispatcher injection workaround, as WordPress 7 RC1 now correctly passes the dispatcher to the SDK. This affects both the main plugin logic and documentation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R18) [[2]](diffhunk://#diff-d3a5439f0bd12fb99d4bc5a9dcf6debd38c483728d36a50395e2f3a8d87934cbL36-R46) [[3]](diffhunk://#diff-d3a5439f0bd12fb99d4bc5a9dcf6debd38c483728d36a50395e2f3a8d87934cbL191-L203) [[4]](diffhunk://#diff-f535d7e7b2c414a8a4600f6776d9f1acafa2dd251bbae5524bfa39ba7e7c25c0L10-L25) [[5]](diffhunk://#diff-f535d7e7b2c414a8a4600f6776d9f1acafa2dd251bbae5524bfa39ba7e7c25c0L39-L78) [[6]](diffhunk://#diff-d9defc501604f10198d40c2ba2e63d6d1fd402e6152bae2f079c7b722e25fc74L47-L49)
- Updated documentation and troubleshooting steps to indicate that the core bug is resolved and the workaround is no longer needed. [[1]](diffhunk://#diff-d3a5439f0bd12fb99d4bc5a9dcf6debd38c483728d36a50395e2f3a8d87934cbL36-R46) [[2]](diffhunk://#diff-d3a5439f0bd12fb99d4bc5a9dcf6debd38c483728d36a50395e2f3a8d87934cbL240-R169) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L54-R56)

**General plugin updates:**
- Bumped plugin version to 0.5.0 in `ai-valve.php`, `package.json`, and `readme.txt`. [[1]](diffhunk://#diff-c58ca823ac3bbe1661ab06de07740af64ef970f2ec7f7a04c9f948ca3b34abcdL6-R6) [[2]](diffhunk://#diff-c58ca823ac3bbe1661ab06de07740af64ef970f2ec7f7a04c9f948ca3b34abcdL24-R24) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[5]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R68-R72)
- Updated compatibility notes and documentation to state support for WordPress 7 RC1. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R18)

**Documentation improvements:**
- Clarified that AI Valve now relies only on stable public hooks and is compatible with future WordPress updates, removing references to the previous workaround. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L54-R56) [[2]](diffhunk://#diff-d3a5439f0bd12fb99d4bc5a9dcf6debd38c483728d36a50395e2f3a8d87934cbL36-R46) [[3]](diffhunk://#diff-d3a5439f0bd12fb99d4bc5a9dcf6debd38c483728d36a50395e2f3a8d87934cbL191-L203)

These changes ensure that AI Valve works seamlessly with the latest WordPress 7 RC1 and that users and developers have up-to-date guidance.