### PR TITLE
v1.0.0: Pending-row pattern for WP 7 AI Client interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-15
+
+### Fixed
+
+- AI requests that fail (auth errors, timeouts, bad deployments) are now logged with `status = 'error'` instead of being silently lost.
+- Schema migrations now run on every load (version-gated) via `LogRepository::maybe_upgrade()`, so in-place file updates without deactivate/activate no longer leave the DB in an outdated state.
+
+### Changed
+
+- `on_before_generate` now inserts a pending log row immediately, ensuring every request that enters the AI pipeline is visible — even if the SDK throws before the after-event fires.
+- `on_after_generate` updates the pending row with token counts and `status = 'allowed'` instead of inserting a new row.
+- Added shutdown handler to catch orphaned pending rows and mark them as errors.
+- Added `LogRepository::update()` method for updating existing log rows by ID.
+- Extracted `LogRepository::run_migrations()` from `activate()`; new `maybe_upgrade()` calls it when the stored schema version is behind.
+
 ## [0.6.0] - 2026-03-25
 
 ### Added
@@ -99,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workaround for WordPress 7.0 event dispatcher bug.
 - GitHub release updater for automatic updates.
 
+[1.0.0]: https://github.com/soderlind/ai-valve/releases/tag/1.0.0
 [0.6.0]: https://github.com/soderlind/ai-valve/releases/tag/0.6.0
 [0.5.0]: https://github.com/soderlind/ai-valve/releases/tag/0.5.0
 [0.4.0]: https://github.com/soderlind/ai-valve/releases/tag/0.4.0

--- a/ai-valve.php
+++ b/ai-valve.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Valve
  * Plugin URI:  https://github.com/soderlind/ai-valve
  * Description: Control, meter, and permission-gate AI usage from plugins that connect through the WordPress 7 AI connector.
- * Version:     0.6.0
+ * Version:     1.0.0
  * Requires at least: 7.0
  * Requires PHP: 8.3
  * Author:      Per Søderlind
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-define( 'AI_VALVE_VERSION', '0.6.0' );
+define( 'AI_VALVE_VERSION', '1.0.0' );
 define( 'AI_VALVE_FILE', __FILE__ );
 define( 'AI_VALVE_DIR', __DIR__ );
 define( 'AI_VALVE_BASENAME', plugin_basename( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ai-valve",
-	"version": "0.6.0",
+	"version": "1.0.0",
 	"private": true,
 	"scripts": {
 		"build": "wp-scripts build src/js/index.js --output-path=build",

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+    "redefinable-internals": [
+        "register_shutdown_function"
+    ]
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, tokens, metering, permissions, usage
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.3
-Stable tag: 0.6.0
+Stable tag: 1.0.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,13 @@ Yes. Each subsite has its own log table, settings, and budgets.
 The plugin receives a `WP_Error` with code `prompt_prevented` instead of an AI response. The denied request is logged with the reason. See [how-blocking-works.md](https://github.com/soderlind/ai-valve/blob/main/docs/how-blocking-works.md) for the full explanation.
 
 == Changelog ==
+
+= 1.0.0 =
+* Fixed: AI requests that fail (auth errors, timeouts, bad deployments) now logged with status = 'error'.
+* Fixed: Schema migrations run on every load (version-gated) so in-place updates work without deactivate/activate.
+* Changed: on_before_generate inserts a pending log row immediately; on_after_generate updates it.
+* Changed: Shutdown handler catches orphaned pending rows and marks them as errors.
+* Added: LogRepository::update() for updating existing log rows by ID.
 
 = 0.6.0 =
 * Added: Request duration tracking (duration_ms column, schema v3).

--- a/src/Interceptor/RequestInterceptor.php
+++ b/src/Interceptor/RequestInterceptor.php
@@ -15,8 +15,12 @@ use WP_AI_Client_Prompt_Builder;
  * Wires the three WP 7 AI connector hooks:
  *
  * 1. `wp_ai_client_prevent_prompt`        — gate / ACL
- * 2. `wp_ai_client_before_generate_result` — start tracking
- * 3. `wp_ai_client_after_generate_result`  — log token usage
+ * 2. `wp_ai_client_before_generate_result` — insert pending log row
+ * 3. `wp_ai_client_after_generate_result`  — finalise with token usage
+ *
+ * If the SDK throws during generation (auth error, timeout, etc.),
+ * the after-event never fires. A shutdown handler catches orphaned
+ * pending rows and marks them as errors.
  */
 final class RequestInterceptor {
 
@@ -24,6 +28,12 @@ final class RequestInterceptor {
 	private static string $current_plugin_slug = '';
 	private static string $current_context     = '';
 	private static float  $request_start_time  = 0.0;
+
+	/** Pending log row ID written in on_before_generate. */
+	private static int $pending_log_id = 0;
+
+	/** Whether the shutdown handler has been registered. */
+	private static bool $shutdown_registered = false;
 
 	public function __construct(
 		private readonly Settings $settings,
@@ -81,7 +91,7 @@ final class RequestInterceptor {
 	}
 
 	/* ------------------------------------------------------------------
-	 * 2. Before generate — capture attribution
+	 * 2. Before generate — insert pending log row
 	 * ----------------------------------------------------------------*/
 
 	public function on_before_generate( BeforeGenerateResultEvent $event ): void {
@@ -94,10 +104,49 @@ final class RequestInterceptor {
 			self::$current_plugin_slug = CallerDetector::detect();
 			self::$current_context     = CallerDetector::context();
 		}
+
+		// Extract provider / model / capability from the event.
+		$model       = $event->getModel();
+		$provider_id = '';
+		$model_id    = '';
+		$capability  = '';
+
+		try {
+			$provider_id = $model->providerMetadata()->getId();
+		} catch ( \Throwable ) {
+		}
+
+		try {
+			$model_id = $model->metadata()->getId();
+		} catch ( \Throwable ) {
+		}
+
+		if ( null !== $event->getCapability() ) {
+			$capability = (string) $event->getCapability();
+		}
+
+		// Write a pending row so the request is visible even if after-event never fires.
+		$repo   = new LogRepository();
+		$row_id = $repo->insert( [
+			'plugin_slug' => self::$current_plugin_slug ?: 'unknown',
+			'provider_id' => $provider_id,
+			'model_id'    => $model_id,
+			'capability'  => $capability,
+			'context'     => self::$current_context ?: CallerDetector::context(),
+			'status'      => 'pending',
+		] );
+
+		self::$pending_log_id = is_int( $row_id ) ? $row_id : 0;
+
+		// Register a one-time shutdown handler to catch orphaned pending rows.
+		if ( ! self::$shutdown_registered ) {
+			self::$shutdown_registered = true;
+			register_shutdown_function( [ self::class, 'finalise_on_shutdown' ] );
+		}
 	}
 
 	/* ------------------------------------------------------------------
-	 * 3. After generate — log token usage
+	 * 3. After generate — finalise pending row with token usage
 	 * ----------------------------------------------------------------*/
 
 	public function on_after_generate( AfterGenerateResultEvent $event ): void {
@@ -130,7 +179,6 @@ final class RequestInterceptor {
 		$total_tokens      = $usage->getTotalTokens();
 
 		$plugin_slug = self::$current_plugin_slug ?: 'unknown';
-		$context     = self::$current_context ?: CallerDetector::context();
 
 		// Compute request duration.
 		$duration_ms = 0;
@@ -138,20 +186,35 @@ final class RequestInterceptor {
 			$duration_ms = (int) round( ( hrtime( true ) - self::$request_start_time ) / 1000000 );
 		}
 
-		// Write to the log table.
 		$repo = new LogRepository();
-		$repo->insert( [
-			'plugin_slug'       => $plugin_slug,
-			'provider_id'       => $provider_id,
-			'model_id'          => $model_id,
-			'capability'        => $capability,
-			'context'           => $context,
-			'prompt_tokens'     => $prompt_tokens,
-			'completion_tokens' => $completion_tokens,
-			'total_tokens'      => $total_tokens,
-			'duration_ms'       => $duration_ms,
-			'status'            => 'allowed',
-		] );
+
+		if ( self::$pending_log_id > 0 ) {
+			// Update the pending row inserted by on_before_generate.
+			$repo->update( self::$pending_log_id, [
+				'provider_id'       => $provider_id,
+				'model_id'          => $model_id,
+				'capability'        => $capability,
+				'prompt_tokens'     => $prompt_tokens,
+				'completion_tokens' => $completion_tokens,
+				'total_tokens'      => $total_tokens,
+				'duration_ms'       => $duration_ms,
+				'status'            => 'allowed',
+			] );
+		} else {
+			// Fallback: no pending row (unlikely but defensive).
+			$repo->insert( [
+				'plugin_slug'       => $plugin_slug,
+				'provider_id'       => $provider_id,
+				'model_id'          => $model_id,
+				'capability'        => $capability,
+				'context'           => self::$current_context ?: CallerDetector::context(),
+				'prompt_tokens'     => $prompt_tokens,
+				'completion_tokens' => $completion_tokens,
+				'total_tokens'      => $total_tokens,
+				'duration_ms'       => $duration_ms,
+				'status'            => 'allowed',
+			] );
+		}
 
 		// Update rolling counters.
 		$this->usage_tracker->record( $plugin_slug, $total_tokens, $provider_id );
@@ -160,6 +223,49 @@ final class RequestInterceptor {
 		self::$current_plugin_slug = '';
 		self::$current_context     = '';
 		self::$request_start_time  = 0.0;
+		self::$pending_log_id      = 0;
 		CallerDetector::reset();
+	}
+
+	/* ------------------------------------------------------------------
+	 * Shutdown handler — catch orphaned pending rows
+	 * ----------------------------------------------------------------*/
+
+	/**
+	 * If on_after_generate never fired, mark the pending row as an error.
+	 *
+	 * @internal Called via register_shutdown_function.
+	 */
+	public static function finalise_on_shutdown(): void {
+		if ( self::$pending_log_id <= 0 ) {
+			return;
+		}
+
+		$duration_ms = 0;
+		if ( self::$request_start_time > 0 ) {
+			$duration_ms = (int) round( ( hrtime( true ) - self::$request_start_time ) / 1000000 );
+		}
+
+		$repo = new LogRepository();
+		$repo->update( self::$pending_log_id, [
+			'duration_ms' => $duration_ms,
+			'status'      => 'error',
+		] );
+
+		self::$pending_log_id     = 0;
+		self::$request_start_time = 0.0;
+	}
+
+	/**
+	 * Reset all static state. Intended for tests only.
+	 *
+	 * @internal
+	 */
+	public static function reset_state(): void {
+		self::$current_plugin_slug = '';
+		self::$current_context     = '';
+		self::$request_start_time  = 0.0;
+		self::$pending_log_id      = 0;
+		self::$shutdown_registered = false;
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -26,6 +26,10 @@ final class Plugin {
 			return;
 		}
 
+		// Run schema migrations on version bump (activation hook only
+		// fires on activate, not on in-place file updates).
+		LogRepository::maybe_upgrade();
+
 		$settings      = new Settings();
 		$usage_tracker = new UsageTracker( $settings );
 		$interceptor   = new RequestInterceptor( $settings, $usage_tracker );

--- a/src/Tracking/LogRepository.php
+++ b/src/Tracking/LogRepository.php
@@ -27,6 +27,25 @@ final class LogRepository {
 	 * ----------------------------------------------------------------*/
 
 	public static function activate(): void {
+		self::run_migrations();
+	}
+
+	/**
+	 * Run schema migrations if the stored version is behind.
+	 *
+	 * Called from Plugin::register() on every request so that in-place
+	 * file updates (without deactivate/activate) still apply migrations.
+	 * The version check makes this a no-op on most requests.
+	 */
+	public static function maybe_upgrade(): void {
+		$current_version = (int) get_option( self::VERSION_KEY, 0 );
+
+		if ( $current_version < self::SCHEMA_VERSION ) {
+			self::run_migrations();
+		}
+	}
+
+	private static function run_migrations(): void {
 		global $wpdb;
 
 		$table   = self::table_name();
@@ -131,6 +150,49 @@ final class LogRepository {
 		);
 
 		return false === $result ? false : (int) $wpdb->insert_id;
+	}
+
+	/* ------------------------------------------------------------------
+	 * Update
+	 * ----------------------------------------------------------------*/
+
+	/**
+	 * Update an existing log row by ID.
+	 *
+	 * @param int                  $id   Row ID to update.
+	 * @param array<string, mixed> $data Column => value pairs to set.
+	 * @return bool True on success, false on failure.
+	 */
+	public function update( int $id, array $data ): bool {
+		global $wpdb;
+
+		$allowed = [
+			'plugin_slug'       => '%s',
+			'provider_id'       => '%s',
+			'model_id'          => '%s',
+			'capability'        => '%s',
+			'context'           => '%s',
+			'prompt_tokens'     => '%d',
+			'completion_tokens' => '%d',
+			'total_tokens'      => '%d',
+			'duration_ms'       => '%d',
+			'status'            => '%s',
+		];
+
+		$set     = array_intersect_key( $data, $allowed );
+		$formats = array_map( static fn( string $col ) => $allowed[ $col ], array_keys( $set ) );
+
+		if ( empty( $set ) ) {
+			return false;
+		}
+
+		return (bool) $wpdb->update(
+			self::table_name(),
+			$set,
+			[ 'id' => $id ],
+			$formats,
+			[ '%d' ]
+		);
 	}
 
 	/* ------------------------------------------------------------------

--- a/tests/Unit/Interceptor/RequestInterceptorTest.php
+++ b/tests/Unit/Interceptor/RequestInterceptorTest.php
@@ -13,6 +13,14 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Events\AfterGenerateResultEvent;
+use WordPress\AiClient\Events\BeforeGenerateResultEvent;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
 
 final class RequestInterceptorTest extends TestCase {
 
@@ -31,6 +39,8 @@ final class RequestInterceptorTest extends TestCase {
 
 	protected function tearDown(): void {
 		CallerDetector::reset();
+		RequestInterceptor::reset_state();
+		unset( $GLOBALS['wpdb'] );
 		Monkey\tearDown();
 		parent::tearDown();
 	}
@@ -128,5 +138,192 @@ final class RequestInterceptorTest extends TestCase {
 
 		$result = $interceptor->maybe_prevent( false, $builder );
 		$this->assertFalse( $result ); // Should allow.
+	}
+
+	/* ------------------------------------------------------------------
+	 * Helper: build mock Model, events, and $wpdb
+	 * ----------------------------------------------------------------*/
+
+	private function make_model( string $provider = 'azure-ai-foundry', string $model = 'gpt-4.1' ): ModelInterface {
+		$mock = $this->createMock( ModelInterface::class );
+		$mock->method( 'providerMetadata' )->willReturn( new ProviderMetadata( $provider, $provider ) );
+		$mock->method( 'metadata' )->willReturn( new ModelMetadata( $model, $model ) );
+		return $mock;
+	}
+
+	private function make_before_event( ?ModelInterface $model = null ): BeforeGenerateResultEvent {
+		return new BeforeGenerateResultEvent(
+			[],
+			$model ?? $this->make_model(),
+			CapabilityEnum::textGeneration(),
+		);
+	}
+
+	private function make_after_event( ?ModelInterface $model = null, int $total = 100 ): AfterGenerateResultEvent {
+		$usage  = new TokenUsage( 40, 60, $total );
+		$result = new GenerativeAiResult( $usage );
+		return new AfterGenerateResultEvent(
+			[],
+			$model ?? $this->make_model(),
+			CapabilityEnum::textGeneration(),
+			$result,
+		);
+	}
+
+	/**
+	 * Create a Mockery $wpdb that expects insert().
+	 *
+	 * @param int $insert_id ID returned by insert.
+	 * @return \Mockery\MockInterface
+	 */
+	private function mock_wpdb( int $insert_id = 42 ): \Mockery\MockInterface {
+		$wpdb = \Mockery::mock( 'wpdb' );
+		$wpdb->prefix    = 'wp_';
+		$wpdb->insert_id = $insert_id;
+		$wpdb->shouldReceive( 'insert' )->andReturnUsing( function () use ( $wpdb, $insert_id ) {
+			$wpdb->insert_id = $insert_id;
+			return 1;
+		} );
+		$GLOBALS['wpdb'] = $wpdb;
+		return $wpdb;
+	}
+
+	private function stub_caller_detector_deps(): void {
+		Functions\when( 'wp_normalize_path' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'wp_doing_cron' )->justReturn( false );
+		Functions\when( 'wp_doing_ajax' )->justReturn( false );
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\when( 'get_theme_root' )->justReturn( '/tmp/themes' );
+	}
+
+	/* ------------------------------------------------------------------
+	 * on_before_generate — inserts a pending row
+	 * ----------------------------------------------------------------*/
+
+	public function test_on_before_generate_inserts_pending_row(): void {
+		$this->stub_caller_detector_deps();
+		Functions\when( 'register_shutdown_function' )->justReturn( true );
+
+		$wpdb = \Mockery::mock( 'wpdb' );
+		$wpdb->prefix    = 'wp_';
+		$wpdb->insert_id = 42;
+
+		// Expect insert is called with status = 'pending'.
+		$captured_data = null;
+		$wpdb->shouldReceive( 'insert' )->once()->andReturnUsing(
+			function ( $table, $data ) use ( $wpdb, &$captured_data ) {
+				$captured_data = $data;
+				$wpdb->insert_id = 42;
+				return 1;
+			}
+		);
+
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$interceptor = new RequestInterceptor( $this->settings, $this->usage_tracker );
+		$interceptor->on_before_generate( $this->make_before_event() );
+
+		$this->assertNotNull( $captured_data );
+		$this->assertSame( 'pending', $captured_data['status'] );
+
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/* ------------------------------------------------------------------
+	 * on_after_generate — updates pending row to allowed
+	 * ----------------------------------------------------------------*/
+
+	public function test_on_after_generate_updates_pending_row_to_allowed(): void {
+		$this->stub_caller_detector_deps();
+		Functions\when( 'register_shutdown_function' )->justReturn( true );
+		Functions\when( 'update_option' )->justReturn( true );
+
+		$wpdb = $this->mock_wpdb( 42 );
+
+		// Capture the update call to verify status.
+		$updated_data = null;
+		$wpdb->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $table, $data, $where ) use ( &$updated_data ) {
+				$updated_data = $data;
+				return 1;
+			}
+		);
+
+		$interceptor = new RequestInterceptor( $this->settings, $this->usage_tracker );
+
+		// Simulate the full lifecycle: before → after.
+		$model = $this->make_model();
+		$interceptor->on_before_generate( $this->make_before_event( $model ) );
+		$interceptor->on_after_generate( $this->make_after_event( $model, 100 ) );
+
+		$this->assertNotNull( $updated_data );
+		$this->assertSame( 'allowed', $updated_data['status'] );
+		$this->assertSame( 100, $updated_data['total_tokens'] );
+
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/* ------------------------------------------------------------------
+	 * finalise_on_shutdown — marks orphaned pending row as error
+	 * ----------------------------------------------------------------*/
+
+	public function test_finalise_on_shutdown_marks_pending_as_error(): void {
+		$this->stub_caller_detector_deps();
+		Functions\when( 'register_shutdown_function' )->justReturn( true );
+
+		$wpdb = $this->mock_wpdb( 99 );
+
+		// Capture the update call from the shutdown handler.
+		$updated_data = null;
+		$wpdb->shouldReceive( 'update' )->once()->andReturnUsing(
+			function ( $table, $data, $where ) use ( &$updated_data ) {
+				$updated_data = $data;
+				return 1;
+			}
+		);
+
+		$interceptor = new RequestInterceptor( $this->settings, $this->usage_tracker );
+
+		// Only call before — simulates SDK exception preventing after-event.
+		$interceptor->on_before_generate( $this->make_before_event() );
+
+		// Invoke the shutdown handler manually.
+		RequestInterceptor::finalise_on_shutdown();
+
+		$this->assertNotNull( $updated_data );
+		$this->assertSame( 'error', $updated_data['status'] );
+		$this->assertArrayHasKey( 'duration_ms', $updated_data );
+
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/* ------------------------------------------------------------------
+	 * finalise_on_shutdown — no-op when after-event already ran
+	 * ----------------------------------------------------------------*/
+
+	public function test_finalise_on_shutdown_noop_when_after_event_ran(): void {
+		$this->stub_caller_detector_deps();
+		Functions\when( 'register_shutdown_function' )->justReturn( true );
+		Functions\when( 'update_option' )->justReturn( true );
+
+		$wpdb = $this->mock_wpdb( 42 );
+
+		// Allow exactly one update call (from on_after_generate).
+		$wpdb->shouldReceive( 'update' )->once()->andReturn( 1 );
+
+		$interceptor = new RequestInterceptor( $this->settings, $this->usage_tracker );
+
+		$model = $this->make_model();
+		$interceptor->on_before_generate( $this->make_before_event( $model ) );
+		$interceptor->on_after_generate( $this->make_after_event( $model ) );
+
+		// Shutdown should do nothing (pending_log_id already cleared).
+		RequestInterceptor::finalise_on_shutdown();
+
+		// If we reach here without extra update calls, test passes.
+		$this->assertTrue( true );
+
+		unset( $GLOBALS['wpdb'] );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,3 +39,7 @@ if ( ! class_exists( 'WP_AI_Client_Prompt_Builder' ) ) {
 	// @phpcs:ignore
 	class WP_AI_Client_Prompt_Builder {}
 }
+
+// Stub WordPress\AiClient SDK classes used by RequestInterceptor.
+require_once __DIR__ . '/stubs/ai-client-sdk.php';
+

--- a/tests/stubs/ai-client-sdk.php
+++ b/tests/stubs/ai-client-sdk.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Minimal stubs for WordPress\AiClient SDK classes.
+ *
+ * These allow PHPUnit + Brain Monkey tests to instantiate / mock the
+ * event objects without the real SDK installed.
+ */
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\Models\Enums;
+
+if ( ! class_exists( CapabilityEnum::class ) ) {
+	class CapabilityEnum {
+		private string $value;
+		private function __construct( string $value ) { $this->value = $value; }
+		public static function textGeneration(): self { return new self( 'text_generation' ); }
+		public function __toString(): string { return $this->value; }
+	}
+}
+
+namespace WordPress\AiClient\Providers\DTO;
+
+if ( ! class_exists( ProviderMetadata::class ) ) {
+	class ProviderMetadata {
+		public function __construct( private readonly string $id = '', private readonly string $name = '' ) {}
+		public function getId(): string { return $this->id; }
+		public function getName(): string { return $this->name; }
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\DTO;
+
+if ( ! class_exists( ModelMetadata::class ) ) {
+	class ModelMetadata {
+		public function __construct( private readonly string $id = '', private readonly string $name = '' ) {}
+		public function getId(): string { return $this->id; }
+		public function getName(): string { return $this->name; }
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\Contracts;
+
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+
+if ( ! interface_exists( ModelInterface::class ) ) {
+	interface ModelInterface {
+		public function metadata(): ModelMetadata;
+		public function providerMetadata(): ProviderMetadata;
+	}
+}
+
+namespace WordPress\AiClient\Results\DTO;
+
+if ( ! class_exists( TokenUsage::class ) ) {
+	class TokenUsage {
+		public function __construct(
+			private readonly int $promptTokens = 0,
+			private readonly int $completionTokens = 0,
+			private readonly int $totalTokens = 0,
+		) {}
+		public function getPromptTokens(): int { return $this->promptTokens; }
+		public function getCompletionTokens(): int { return $this->completionTokens; }
+		public function getTotalTokens(): int { return $this->totalTokens; }
+	}
+}
+
+if ( ! class_exists( GenerativeAiResult::class ) ) {
+	class GenerativeAiResult {
+		public function __construct( private readonly TokenUsage $tokenUsage = new TokenUsage() ) {}
+		public function getTokenUsage(): TokenUsage { return $this->tokenUsage; }
+	}
+}
+
+namespace WordPress\AiClient\Events;
+
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+
+if ( ! class_exists( BeforeGenerateResultEvent::class ) ) {
+	class BeforeGenerateResultEvent {
+		public function __construct(
+			private readonly array $messages,
+			private readonly ModelInterface $model,
+			private readonly ?CapabilityEnum $capability = null,
+		) {}
+		public function getMessages(): array { return $this->messages; }
+		public function getModel(): ModelInterface { return $this->model; }
+		public function getCapability(): ?CapabilityEnum { return $this->capability; }
+	}
+}
+
+if ( ! class_exists( AfterGenerateResultEvent::class ) ) {
+	class AfterGenerateResultEvent {
+		public function __construct(
+			private readonly array $messages,
+			private readonly ModelInterface $model,
+			private readonly ?CapabilityEnum $capability = null,
+			private readonly ?GenerativeAiResult $result = null,
+		) {}
+		public function getMessages(): array { return $this->messages; }
+		public function getModel(): ModelInterface { return $this->model; }
+		public function getCapability(): ?CapabilityEnum { return $this->capability; }
+		public function getResult(): GenerativeAiResult { return $this->result ?? new GenerativeAiResult(); }
+	}
+}


### PR DESCRIPTION
- Rewrite RequestInterceptor with pending-row pattern: before→pending, after→allowed, shutdown→error for failed requests
- Add LogRepository::update() and maybe_upgrade() for version-gated schema migrations
- Add SDK stubs and 4 new tests for pending-row lifecycle
- Bump version to 1.0.0