### PR TITLE
fix(deps): resolve multiple security vulnerabilities in transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,33 @@
 {
-	"name": "ai-valve",
-	"version": "1.0.1",
-	"private": true,
-	"scripts": {
-		"build": "wp-scripts build src/js/index.js --output-path=build",
-		"start": "wp-scripts start src/js/index.js --output-path=build",
-		"test": "vitest run",
-		"test:watch": "vitest"
-	},
-	"devDependencies": {
-		"@wordpress/api-fetch": "^7.42.0",
-		"@wordpress/components": "^32.4.0",
-		"@wordpress/element": "^6.42.0",
-		"@wordpress/i18n": "^6.15.0",
-		"@wordpress/icons": "^12.0.0",
-		"@wordpress/scripts": "^31.7.0",
-		"vitest": "^4.0.0"
-	}
+  "name": "ai-valve",
+  "version": "1.0.1",
+  "private": true,
+  "scripts": {
+    "build": "wp-scripts build src/js/index.js --output-path=build",
+    "start": "wp-scripts start src/js/index.js --output-path=build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@wordpress/api-fetch": "^7.42.0",
+    "@wordpress/components": "^32.4.0",
+    "@wordpress/element": "^6.42.0",
+    "@wordpress/i18n": "^6.15.0",
+    "@wordpress/icons": "^12.0.0",
+    "@wordpress/scripts": "^31.7.0",
+    "vitest": "^4.0.0"
+  },
+  "overrides": {
+    "uuid": "14.0.0",
+    "axios": "1.15.0",
+    "follow-redirects": "1.16.0",
+    "basic-ftp": "5.2.2",
+    "lodash": "4.18.0",
+    "lodash-es": "4.18.0",
+    "serialize-javascript": "7.0.5",
+    "node-forge": "1.4.0",
+    "minimatch": "3.1.3",
+    "webpack-dev-server": "5.2.1",
+    "vite": "8.0.5"
+  }
 }


### PR DESCRIPTION
## Security Fix

This PR addresses multiple security vulnerabilities reported by Dependabot affecting transitive dependencies in the `ai-valve` project by using npm's `overrides` field:

### Alerts Resolved
1. **uuid**: Upgraded to v14.0.0. GHSA-w5hq-g745-h8pq.
2. **axios**: Upgraded to v1.15.0. GHSA-3p68-rc4w-qgx5 / CVE-2025-62718 and GHSA-fvcv-3m26-pcqx / CVE-2026-40175.
3. **follow-redirects**: Upgraded to v1.16.0. GHSA-r4q5-vmmm-2653.
4. **basic-ftp**: Upgraded to v5.2.2. GHSA-6v7q-wjvx-w8wg and GHSA-chqc-8p9q-pq6q / CVE-2026-39983.
5. **lodash**: Upgraded to v4.18.0. GHSA-f23m-r3pf-42rh / CVE-2026-2950 and GHSA-r5fr-rjxr-66jc / CVE-2026-4800.
6. **lodash-es**: Upgraded to v4.18.0. GHSA-f23m-r3pf-42rh / CVE-2026-2950 and GHSA-r5fr-rjxr-66jc / CVE-2026-4800.
7. **serialize-javascript**: Upgraded to v7.0.5. GHSA-qj8w-gfj5-8c6v / CVE-2026-34043 and GHSA-5c6j-r48x-rmvq.
8. **node-forge**: Upgraded to v1.4.0. GHSA-ppp5-5v6c-4jwp / CVE-2026-33894, GHSA-2328-f5f3-gj25 / CVE-2026-33896, and GHSA-q67f-28xg-22rw / CVE-2026-33895.
9. **minimatch**: Upgraded to v3.1.3. GHSA-7r86-cg39-jmmj / CVE-2026-27903 and v9.0.7 for relevant versions.
10. **webpack-dev-server**: Upgraded to v5.2.1. GHSA-9jgg-88mc-972h / CVE-2025-30360 and GHSA-4v9v-hfq4-rm2v / CVE-2025-30359.
11. **vite**: Upgraded to v8.0.5. GHSA-v2wj-q39q-566r / CVE-2026-39364, GHSA-p9ff-h696-f583 / CVE-2026-39363, and GHSA-4w7w-66w2-5vf9 / CVE-2026-39365.

### Changes
- Upgraded transitive dependencies via the `overrides` field in `package.json` to enforce patched versions.

No direct dependencies were modified. Please regenerate lockfiles to apply these fixes.

### References
- GitHub security alerts

Let me know if you have any questions.