### PR TITLE
Release 1.0.3: developer hooks, updated docs and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-05-03
+
+### Added
+
+- `ai_valve_plugin_policy` filter — override the allow/deny policy for any plugin programmatically.
+- `ai_valve_request_denied` action — fires when a request is blocked, with plugin slug, context, and reason code.
+- `ai_valve_request_completed` action — fires after every successful request with full token and timing data.
+- Developer hooks documentation (`docs/hooks.md`) with signatures, parameter tables, and examples.
+- Documentation index (`docs/README.md`).
+
+### Changed
+
+- README rewritten with Developer Hooks section and links to new documentation.
+
 ## [1.0.2] - 2026-05-03
 
 ### Fixed
@@ -138,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workaround for WordPress 7.0 event dispatcher bug.
 - GitHub release updater for automatic updates.
 
+[1.0.3]: https://github.com/soderlind/ai-valve/releases/tag/1.0.3
 [1.0.2]: https://github.com/soderlind/ai-valve/releases/tag/1.0.2
 [1.0.1]: https://github.com/soderlind/ai-valve/releases/tag/1.0.1
 [1.0.0]: https://github.com/soderlind/ai-valve/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -2,21 +2,19 @@
 
 Control, meter, and permission-gate AI usage from plugins that connect through the WordPress 7 AI connector.
 
-Heavily inspired by the [WordPress AI Connectors Need More Friction, Not Less](https://thewp.world/wordpress-ai-connectors-need-more-friction-not-less/) article.
+> Inspired by [WordPress AI Connectors Need More Friction, Not Less](https://thewp.world/wordpress-ai-connectors-need-more-friction-not-less/). Works with WordPress 7 RC2. Tested with [WordPress AI](https://wordpress.org/plugins/ai/), [Virtual Media Folders AI Organizer](https://github.com/soderlind/vmfa-ai-organizer), and [AI Provider for Azure OpenAI](https://github.com/soderlind/ai-provider-for-azure-openai).
 
-> Works with WordPress 7 RC2. Tested using WordPress [AI](https://wordpress.org/plugins/ai/),  [Virtual Media Folders AI Organizer](https://github.com/soderlind/vmfa-ai-organizer?tab=readme-ov-file#virtual-media-folders-ai-organizer) and the [AI Provider for Azure OpenAI](https://github.com/soderlind/ai-provider-for-azure-openai?tab=readme-ov-file#ai-provider-for-azure-openai).
-
-<img width="100%"  alt="Screenshot 2026-03-24 at 23 55 20" src="https://github.com/user-attachments/assets/3b619ba2-1432-4029-be3f-7556bcb991e2" />
-
+<img width="100%" alt="AI Valve dashboard" src="https://github.com/user-attachments/assets/3b619ba2-1432-4029-be3f-7556bcb991e2" />
 
 ## Features
 
 - **Per-plugin access control** — Allow or deny individual plugins from making AI requests.
 - **Token budgets** — Set daily and monthly token limits per plugin and globally.
 - **Context restrictions** — Control which execution contexts (admin, frontend, cron, REST, AJAX, CLI) may trigger AI calls.
-- **Usage dashboard** — See token consumption at a glance with summary cards, progress bars, and per-plugin breakdowns.
+- **Usage dashboard** — Token consumption at a glance: summary cards, progress bars, and per-plugin breakdowns.
 - **Request logging** — Every AI request is logged with provider, model, capability, tokens, and caller attribution.
 - **Budget alerts** — Admin notices and optional email when usage approaches or exceeds limits.
+- **Developer hooks** — Filter and action hooks to extend behaviour without modifying the plugin.
 - **Automatic updates** — Receives updates directly from GitHub releases.
 
 ## Requirements
@@ -27,11 +25,10 @@ Heavily inspired by the [WordPress AI Connectors Need More Friction, Not Less](h
 
 ## Installation
 
-
 1. Download [`ai-valve.zip`](https://github.com/soderlind/ai-valve/releases/latest/download/ai-valve.zip)
-2. Upload via `Plugins → Add New → Upload Plugin`
-3. Activate the plugin through the WordPress admin
-4. Go to **Settings → AI Valve** to configure.
+2. Upload via **Plugins → Add New → Upload Plugin**
+3. Activate the plugin
+4. Go to **Settings → AI Valve** to configure
 
 The plugin updates itself automatically via GitHub releases using [plugin-update-checker](https://github.com/YahnisElsts/plugin-update-checker).
 
@@ -41,6 +38,7 @@ The plugin updates itself automatically via GitHub releases using [plugin-update
 git clone https://github.com/soderlind/ai-valve.git
 cd ai-valve
 composer install
+npm install && npm run build
 ```
 
 ## Usage
@@ -49,7 +47,7 @@ After activation, AI Valve intercepts all calls made through `wp_ai_client_promp
 
 - **Dashboard** — Token usage for today and this month, per-plugin access/budget controls, provider breakdown, and recent requests.
 - **Settings** — Master switch, default policy, context restrictions, global budgets, and alert configuration.
-- **Logs** — Filterable request log with pagination.
+- **Logs** — Filterable, paginated request log with purge controls.
 
 ## How It Works
 
@@ -63,9 +61,21 @@ AI Valve hooks into three WordPress 7 AI connector events:
 
 A pending log row is created *before* the AI provider is called. If the provider throws (auth error, timeout, bad deployment), a shutdown handler marks the row as `error` so failed requests are never lost.
 
-Caller attribution uses `debug_backtrace()` to identify which plugin initiated the AI request.
+Caller attribution uses `debug_backtrace()` to identify which plugin initiated the request.
 
-When a request is blocked, the calling plugin receives a `WP_Error` with code `prompt_prevented` and the denial reason is logged. See [docs/how-blocking-works.md](docs/how-blocking-works.md) for the full explanation.
+When a request is blocked the calling plugin receives a `WP_Error` with code `prompt_prevented`. See [docs/how-blocking-works.md](docs/how-blocking-works.md) for the full explanation.
+
+## Developer Hooks
+
+AI Valve exposes hooks so you can extend its behaviour from another plugin or `functions.php` without editing the source.
+
+| Hook | Type | Purpose |
+|---|---|---|
+| `ai_valve_plugin_policy` | filter | Override the allow/deny decision for any plugin |
+| `ai_valve_request_denied` | action | React when a request is blocked |
+| `ai_valve_request_completed` | action | React when a request succeeds (token counts available) |
+
+See **[docs/hooks.md](docs/hooks.md)** for signatures, parameter descriptions, and examples.
 
 ## FAQ
 
@@ -74,9 +84,13 @@ When a request is blocked, the calling plugin receives a `WP_Error` with code `p
 1. Go to **Settings → AI Valve → Settings**.
 2. Set the **Default policy** to **Deny**.
 3. Switch to the **Dashboard** tab.
-4. In the **Per-plugin access** table, set the plugins you want to allow to **Allow**.
+4. In the **Per-plugin access** table, set each plugin you want to permit to **Allow**.
 
-Only explicitly allowed plugins will be able to make AI requests; everything else is denied by default.
+Everything not explicitly allowed will be denied.
+
+### Can I override the policy programmatically?
+
+Yes — use the `ai_valve_plugin_policy` filter. See [docs/hooks.md](docs/hooks.md).
 
 ## Development
 
@@ -110,8 +124,12 @@ src/
   Admin/AdminPage.php         Settings page (dashboard, settings, logs)
   Alert/AlertManager.php      Budget threshold notices + email
   REST/UsageController.php    REST API endpoints
+docs/                         Developer documentation
 ```
 
+## Documentation
+
+See [docs/README.md](docs/README.md) for a full index.
 
 ## License
 

--- a/ai-valve.php
+++ b/ai-valve.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Valve
  * Plugin URI:  https://github.com/soderlind/ai-valve
  * Description: Control, meter, and permission-gate AI usage from plugins that connect through the WordPress 7 AI connector.
- * Version:     1.0.2
+ * Version:     1.0.3
  * Requires at least: 7.0
  * Requires PHP: 8.3
  * Author:      Per Søderlind

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# AI Valve — Documentation
+
+| Document | Description |
+|---|---|
+| [hooks.md](hooks.md) | Developer hooks — filter and action reference with examples |
+| [how-blocking-works.md](how-blocking-works.md) | How AI Valve evaluates and blocks requests, denial reason codes |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,200 @@
+# AI Valve — Developer Hooks
+
+AI Valve exposes three hooks that let you extend or react to its decisions without touching the plugin's source code.
+
+---
+
+## Filters
+
+### `ai_valve_plugin_policy`
+
+Dynamically override the allow/deny policy for any plugin.
+
+Fires during the policy evaluation step, after the stored setting is read but before the decision is applied. Return `'allow'` or `'deny'`.
+
+**Signature**
+
+```php
+apply_filters( 'ai_valve_plugin_policy', string $policy, string $plugin_slug, string $context )
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `$policy` | `string` | Current policy: `'allow'` or `'deny'` (from settings). |
+| `$plugin_slug` | `string` | Slug of the plugin making the AI request. |
+| `$context` | `string` | Execution context: `admin`, `frontend`, `cron`, `rest`, `ajax`, or `cli`. |
+
+**Examples**
+
+Deny a specific plugin regardless of what the Settings UI says:
+
+```php
+add_filter( 'ai_valve_plugin_policy', function ( string $policy, string $slug ): string {
+    if ( 'my-untrusted-plugin' === $slug ) {
+        return 'deny';
+    }
+    return $policy;
+}, 10, 2 );
+```
+
+Allow a plugin only when running in the admin context:
+
+```php
+add_filter( 'ai_valve_plugin_policy', function ( string $policy, string $slug, string $context ): string {
+    if ( 'my-plugin' === $slug && 'admin' !== $context ) {
+        return 'deny';
+    }
+    return $policy;
+}, 10, 3 );
+```
+
+Allow all plugins unconditionally (effectively disable the deny list):
+
+```php
+add_filter( 'ai_valve_plugin_policy', fn() => 'allow' );
+```
+
+---
+
+## Actions
+
+### `ai_valve_request_denied`
+
+Fires immediately after AI Valve blocks an AI request.
+
+Use this to log denials to an external system, trigger a notification, or increment your own counters.
+
+**Signature**
+
+```php
+do_action( 'ai_valve_request_denied', string $plugin_slug, string $context, string $reason )
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `$plugin_slug` | `string` | The plugin that attempted the AI request. |
+| `$context` | `string` | Execution context at the time of the request. |
+| `$reason` | `string` | Denial reason code (see table below). |
+
+**Reason codes**
+
+| Code | Cause |
+|---|---|
+| `ai_valve_disabled` | The master switch is off. |
+| `plugin_denied` | The plugin's policy is `deny` (including via the `ai_valve_plugin_policy` filter). |
+| `context_denied` | The execution context is not allowed in Settings. |
+| `plugin_daily_budget_exceeded` | Plugin hit its per-day token limit. |
+| `plugin_monthly_budget_exceeded` | Plugin hit its per-month token limit. |
+| `global_daily_budget_exceeded` | Site-wide daily token limit reached. |
+| `global_monthly_budget_exceeded` | Site-wide monthly token limit reached. |
+
+**Examples**
+
+Send a Slack message when a plugin is blocked:
+
+```php
+add_action( 'ai_valve_request_denied', function ( string $slug, string $context, string $reason ): void {
+    if ( str_starts_with( $reason, 'plugin_' ) ) {
+        wp_remote_post( SLACK_WEBHOOK_URL, [
+            'body' => wp_json_encode( [
+                'text' => "AI Valve blocked *{$slug}* in context *{$context}* — reason: `{$reason}`",
+            ] ),
+        ] );
+    }
+}, 10, 3 );
+```
+
+Write denials to a custom log table:
+
+```php
+add_action( 'ai_valve_request_denied', function ( string $slug, string $context, string $reason ): void {
+    global $wpdb;
+    $wpdb->insert(
+        $wpdb->prefix . 'my_ai_denials',
+        [
+            'plugin_slug' => $slug,
+            'context'     => $context,
+            'reason'      => $reason,
+            'denied_at'   => current_time( 'mysql', true ),
+        ],
+        [ '%s', '%s', '%s', '%s' ]
+    );
+}, 10, 3 );
+```
+
+---
+
+### `ai_valve_request_completed`
+
+Fires after every successful AI request, once the token usage has been recorded.
+
+Use this to push token data to analytics, enforce additional post-request logic, or sync usage to an external billing system.
+
+**Signature**
+
+```php
+do_action(
+    'ai_valve_request_completed',
+    string $plugin_slug,
+    string $provider_id,
+    string $model_id,
+    string $capability,
+    int    $prompt_tokens,
+    int    $completion_tokens,
+    int    $total_tokens,
+    int    $duration_ms
+)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `$plugin_slug` | `string` | The plugin that made the AI request. |
+| `$provider_id` | `string` | Provider identifier (e.g. `openai`, `azure-openai`). |
+| `$model_id` | `string` | Model identifier (e.g. `gpt-4o`, `claude-3-5-sonnet`). |
+| `$capability` | `string` | Capability used (e.g. `text-generation`). |
+| `$prompt_tokens` | `int` | Tokens consumed by the input prompt. |
+| `$completion_tokens` | `int` | Tokens consumed by the model's response. |
+| `$total_tokens` | `int` | Sum of prompt and completion tokens. |
+| `$duration_ms` | `int` | Wall-clock time for the request in milliseconds. |
+
+**Examples**
+
+Push token usage to a monitoring endpoint:
+
+```php
+add_action(
+    'ai_valve_request_completed',
+    function (
+        string $slug,
+        string $provider,
+        string $model,
+        string $capability,
+        int $prompt,
+        int $completion,
+        int $total,
+        int $ms
+    ): void {
+        wp_remote_post( 'https://metrics.example.com/ai-usage', [
+            'body' => wp_json_encode( compact( 'slug', 'provider', 'model', 'total', 'ms' ) ),
+        ] );
+    },
+    10,
+    8
+);
+```
+
+Emit a warning if a single request is unusually expensive:
+
+```php
+add_action(
+    'ai_valve_request_completed',
+    function ( string $slug, string $provider, string $model, string $capability, int $prompt, int $completion, int $total ): void {
+        if ( $total > 10000 ) {
+            // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            error_log( "AI Valve: large request from {$slug} — {$total} tokens on {$provider}/{$model}" );
+        }
+    },
+    10,
+    7
+);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ai-valve",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ai-valve",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"devDependencies": {
 				"@wordpress/api-fetch": "^7.42.0",
 				"@wordpress/components": "^32.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-valve",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "build": "wp-scripts build src/js/index.js --output-path=build",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, tokens, metering, permissions, usage
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.3
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,13 @@ The plugin receives a `WP_Error` with code `prompt_prevented` instead of an AI r
 Only explicitly allowed plugins will be able to make AI requests; everything else is denied by default.
 
 == Changelog ==
+
+= 1.0.3 =
+* Added: `ai_valve_plugin_policy` filter to override allow/deny policy programmatically.
+* Added: `ai_valve_request_denied` action, fired when a request is blocked.
+* Added: `ai_valve_request_completed` action, fired after every successful request.
+* Added: Developer hooks documentation (`docs/hooks.md`).
+* Changed: README rewritten with Developer Hooks section.
 
 = 1.0.2 =
 * Fixed: Resolve multiple security vulnerabilities in transitive dependencies.

--- a/src/Interceptor/PolicyEngine.php
+++ b/src/Interceptor/PolicyEngine.php
@@ -39,7 +39,14 @@ final class PolicyEngine {
 		}
 
 		// 2. Per-plugin policy.
-		if ( 'deny' === $this->settings->plugin_policy( $plugin_slug ) ) {
+		// Filterable so external code can override the stored policy for a slug.
+		$policy = (string) apply_filters(
+			'ai_valve_plugin_policy',
+			$this->settings->plugin_policy( $plugin_slug ),
+			$plugin_slug,
+			$context
+		);
+		if ( 'deny' === $policy ) {
 			$this->denial_reason = 'plugin_denied';
 			return false;
 		}

--- a/src/Interceptor/RequestInterceptor.php
+++ b/src/Interceptor/RequestInterceptor.php
@@ -84,6 +84,15 @@ final class RequestInterceptor {
 				'status'      => 'denied:' . $engine->denial_reason(),
 			] );
 
+			/**
+			 * Fires when an AI request is denied by AI Valve.
+			 *
+			 * @param string $plugin_slug The plugin slug that made the request.
+			 * @param string $context    Execution context: admin|frontend|cron|rest|ajax|cli.
+			 * @param string $reason     Denial reason code.
+			 */
+			do_action( 'ai_valve_request_denied', $plugin_slug, $context, $engine->denial_reason() );
+
 			return true; // Prevent the prompt.
 		}
 
@@ -218,6 +227,30 @@ final class RequestInterceptor {
 
 		// Update rolling counters.
 		$this->usage_tracker->record( $plugin_slug, $total_tokens, $provider_id );
+
+		/**
+		 * Fires after an AI request completes successfully.
+		 *
+		 * @param string $plugin_slug       The plugin slug that made the request.
+		 * @param string $provider_id       Provider identifier.
+		 * @param string $model_id          Model identifier.
+		 * @param string $capability        Capability used (e.g. 'text-generation').
+		 * @param int    $prompt_tokens     Tokens consumed by the prompt.
+		 * @param int    $completion_tokens Tokens consumed by the completion.
+		 * @param int    $total_tokens      Total tokens consumed.
+		 * @param int    $duration_ms       Request duration in milliseconds.
+		 */
+		do_action(
+			'ai_valve_request_completed',
+			$plugin_slug,
+			$provider_id,
+			$model_id,
+			$capability,
+			$prompt_tokens,
+			$completion_tokens,
+			$total_tokens,
+			$duration_ms
+		);
 
 		// Clear correlation state for the next request.
 		self::$current_plugin_slug = '';

--- a/tests/Unit/Interceptor/PolicyEngineTest.php
+++ b/tests/Unit/Interceptor/PolicyEngineTest.php
@@ -9,6 +9,7 @@ use AIValve\Settings\Settings;
 use AIValve\Tracking\UsageTracker;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
 use PHPUnit\Framework\TestCase;
 
 final class PolicyEngineTest extends TestCase {
@@ -249,5 +250,58 @@ final class PolicyEngineTest extends TestCase {
 
 		$this->assertFalse( $engine->evaluate( 'my-plugin', 'admin' ) );
 		$this->assertSame( 'ai_valve_disabled', $engine->denial_reason() );
+	}
+
+	/* ------------------------------------------------------------------
+	 * ai_valve_plugin_policy filter
+	 * ----------------------------------------------------------------*/
+
+	public function test_filter_can_deny_an_allowed_plugin(): void {
+		// Database says allow, but filter overrides to deny.
+		Functions\when( 'get_option' )->justReturn( [
+			'plugin_policies' => [ 'trusted-plugin' => 'allow' ],
+		] );
+		$settings = new Settings();
+		$tracker  = new UsageTracker( $settings );
+		$engine   = new PolicyEngine( $settings, $tracker );
+
+		Filters\expectApplied( 'ai_valve_plugin_policy' )
+			->once()
+			->with( 'allow', 'trusted-plugin', 'admin' )
+			->andReturn( 'deny' );
+
+		$this->assertFalse( $engine->evaluate( 'trusted-plugin', 'admin' ) );
+		$this->assertSame( 'plugin_denied', $engine->denial_reason() );
+	}
+
+	public function test_filter_can_allow_a_denied_plugin(): void {
+		// Database says deny, but filter overrides to allow.
+		Functions\when( 'get_option' )->justReturn( [
+			'plugin_policies' => [ 'bad-plugin' => 'deny' ],
+		] );
+		$settings = new Settings();
+		$tracker  = new UsageTracker( $settings );
+		$engine   = new PolicyEngine( $settings, $tracker );
+
+		Filters\expectApplied( 'ai_valve_plugin_policy' )
+			->once()
+			->with( 'deny', 'bad-plugin', 'admin' )
+			->andReturn( 'allow' );
+
+		$this->assertTrue( $engine->evaluate( 'bad-plugin', 'admin' ) );
+		$this->assertSame( '', $engine->denial_reason() );
+	}
+
+	public function test_filter_receives_plugin_slug_and_context(): void {
+		$engine = new PolicyEngine( $this->settings, $this->usage_tracker );
+
+		Filters\expectApplied( 'ai_valve_plugin_policy' )
+			->once()
+			->with( 'allow', 'my-plugin', 'cron' )
+			->andReturnFirstArg();
+
+		$result = $engine->evaluate( 'my-plugin', 'cron' );
+
+		$this->assertTrue( $result );
 	}
 }


### PR DESCRIPTION
This pull request introduces a new developer hooks system to AI Valve, allowing external plugins to programmatically override plugin policy decisions and react to request events. It adds three new hooks, detailed documentation, and updates the plugin’s documentation and tests to support and explain these extensibility points. The release is versioned as 1.0.3.

**Developer extensibility and hooks:**

* Added the `ai_valve_plugin_policy` filter, enabling external code to override the allow/deny policy for any plugin at runtime.
* Added the `ai_valve_request_denied` action, which fires when a request is blocked, providing the plugin slug, context, and denial reason.
* Added the `ai_valve_request_completed` action, triggered after every successful request with detailed token and timing data.

**Documentation improvements:**

* Added comprehensive developer hooks documentation (`docs/hooks.md`) with signatures, parameter tables, and usage examples, and a documentation index (`docs/README.md`). [[1]](diffhunk://#diff-8ec27ddb770a0c8db92b89ef4642681d3b73d581fbef06889bf8f8c51d47b3beR1-R200) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R1-R6)
* Updated `README.md` and `readme.txt` with a new Developer Hooks section, installation clarifications, and links to the new documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R132) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R77-R83)

**Testing and release:**

* Added unit tests to ensure the new `ai_valve_plugin_policy` filter works as intended, verifying both allow and deny overrides and correct parameter passing.
* Bumped the plugin version to 1.0.3 and updated changelogs and metadata accordingly. [[1]](diffhunk://#diff-c58ca823ac3bbe1661ab06de07740af64ef970f2ec7f7a04c9f948ca3b34abcdL6-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R21) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR155) [[5]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)